### PR TITLE
Change %d to optional in mount path

### DIFF
--- a/api/v1/diskconfig_types.go
+++ b/api/v1/diskconfig_types.go
@@ -39,9 +39,9 @@ type DiskConfigSpec struct {
 	//+kubebuilder:validation:Optional
 	Capacity string `json:"capacity,omitempty" yaml:"capacity,omitempty"`
 
-	// MountPointPattern is the mount point of the disk. %d represents disk number in order.
+	// MountPointPattern is the mount point of the disk. %d is optional and represents disk number in order. Will be automatically appended for second drive if missing.
 	//+kubebuilder:default:="/media/discoblocks/<name>-%d"
-	//+kubebuilder:validation:Pattern:="^/(.*)%d(.*)"
+	//+kubebuilder:validation:Pattern:="^/(.*)"
 	//+kubebuilder:validation:Optional
 	MountPointPattern string `json:"mountPointPattern,omitempty" yaml:"mountPointPattern,omitempty"`
 

--- a/config/crd/bases/discoblocks.ondat.io_diskconfigs.yaml
+++ b/config/crd/bases/discoblocks.ondat.io_diskconfigs.yaml
@@ -59,8 +59,9 @@ spec:
               mountPointPattern:
                 default: /media/discoblocks/<name>-%d
                 description: MountPointPattern is the mount point of the disk. %d
-                  represents disk number in order.
-                pattern: ^/(.*)%d(.*)
+                  is optional and represents disk number in order. Will be automatically
+                  appended for second drive if missing.
+                pattern: ^/(.*)
                 type: string
               nodeSelector:
                 description: NodeSelector is a selector which must be true for the

--- a/config/samples/discoblocks.ondat.io_v1_diskconfig-csi.storageos.com.yaml
+++ b/config/samples/discoblocks.ondat.io_v1_diskconfig-csi.storageos.com.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   storageClassName: storageos
   capacity: 1Gi
+  # %d is optional, but will automatically appended for second drive if missing
   mountPointPattern: /media/discoblocks/sample-%d
   nodeSelector:
     matchLabels:

--- a/config/samples/discoblocks.ondat.io_v1_diskconfig-ebs.csi.aws.com.yaml
+++ b/config/samples/discoblocks.ondat.io_v1_diskconfig-ebs.csi.aws.com.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   storageClassName: ebs-sc
   capacity: 1Gi
+  # %d is optional, but will automatically appended for second drive if missing
   mountPointPattern: /media/discoblocks/sample-%d
   nodeSelector:
     matchLabels:

--- a/pkg/utils/helpers.go
+++ b/pkg/utils/helpers.go
@@ -58,7 +58,15 @@ securityContext:
 // RenderMountPoint calculates mount point
 func RenderMountPoint(pattern, name string, index int) string {
 	if pattern == "" {
-		return fmt.Sprintf(defaultMountPattern, name, 0)
+		return fmt.Sprintf(defaultMountPattern, name, index)
+	}
+
+	if index != 0 && !strings.Contains(pattern, "%d") {
+		pattern = pattern + "-%d"
+	}
+
+	if !strings.Contains(pattern, "%d") {
+		return pattern
 	}
 
 	return fmt.Sprintf(pattern, index)

--- a/pkg/utils/helpers_test.go
+++ b/pkg/utils/helpers_test.go
@@ -6,6 +6,53 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestRenderMountPoint(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		pattern            string
+		name               string
+		index              int
+		expectedMountPoint string
+	}{
+		"default": {
+			pattern:            "",
+			name:               "foo",
+			index:              1,
+			expectedMountPoint: "/media/discoblocks/foo-1",
+		},
+		"given-with-order": {
+			pattern:            "/bar-%d",
+			name:               "foo",
+			index:              1,
+			expectedMountPoint: "/bar-1",
+		},
+		"given-without-order-first": {
+			pattern:            "/bar",
+			name:               "foo",
+			index:              0,
+			expectedMountPoint: "/bar",
+		},
+		"given-without-order-second": {
+			pattern:            "/bar",
+			name:               "foo",
+			index:              1,
+			expectedMountPoint: "/bar-1",
+		},
+	}
+
+	for n, c := range cases {
+		c := c
+		t.Run(n, func(t *testing.T) {
+			t.Parallel()
+
+			mountPoint := RenderMountPoint(c.pattern, c.name, c.index)
+
+			assert.Equal(t, c.expectedMountPoint, mountPoint, "invalid mount point")
+		})
+	}
+}
+
 func TestGetSidecarStub(t *testing.T) {
 	_, err := RenderMetricsSidecar()
 


### PR DESCRIPTION
## Description

This change allows users to mount the first disk without numeric order. It makes Discoblocks integration easier for any workloads.

Fixes # https://github.com/ondat/discoblocks/issues/27

## Type of change

Please check options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I wrote unit tests.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
