### PR TITLE
Proper support of DaemonSets

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,17 +46,32 @@ When using such data management platform to overcome the block disk device limit
 - capacity management and monitoring
 - resizing and optimizing layouts related to capacity management
 - decommissioning the devices in secure way
+  - by default every resource created by DiskoBlock has a finalizer, so deletion will be blocked until coresponding DiskConfig is exists
+  - by default every additional disk has owner reference to the first disk ever created for pod, Deletion of first PVC terminates all other
 
 At the current stage, Discoblocks is leveraging the available hyperscaler CSI (Container Storage Interface) within the Kubernetes cluster to:
 - introduce a CRD (Custom Resource Definition) per workload with
+  - StorageClass name
   - capacity
   - mount path within the Pod 
   - nodeSelector
   - podSelector
-  - upscale policy 
+  - access modes: Access mode of PersistentVolume
+  - availability mode:
+    - ReadWriteOnce: New disk for each pod, including pod restart
+    - ReadWriteSame: All pod gets the same volume on the same node
+    - ReadWriteDaemon: DaemonSet pods gets the same volume per node
+  - upscale policy
+    - upscale trigger percentage
+    - maximum capacity of disk
+    - maximum number of disks per pod
+    - extend capacity
+    - cool down period after upscale
+    - pause autoscaling
 - provision the relevant disk device using the CSI (like EBS on AWS) when the workload deployment will happen
 - monitor the volume(s)
 - resize automatically the volume based on the upscale policy
+- create and mount new volume based on the upscale policy
 
 **Note:** that an application could be using Discoblocks to get persistent storage but this option would not be safe for production as there will not be any data platform management to address high availability, replication, fencing, encryption, ...
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ When using such data management platform to overcome the block disk device limit
 - capacity management and monitoring
 - resizing and optimizing layouts related to capacity management
 - decommissioning the devices in secure way
-  - by default every resource created by DiscoBlock has a finalizer, so resource deletion would be on hold by Kubernetes until corresponding DiskConfig is exists
+  - by default every resource created by DiscoBlocks has a finalizer, so deletion will be blocked until the corresponding DiskConfig has been deleted
   - by default every additional disk has owner reference to the first disk ever created for pod, Deletion of first PVC terminates all other
 
 At the current stage, Discoblocks is leveraging the available hyperscaler CSI (Container Storage Interface) within the Kubernetes cluster to:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ When using such data management platform to overcome the block disk device limit
 - capacity management and monitoring
 - resizing and optimizing layouts related to capacity management
 - decommissioning the devices in secure way
-  - by default every resource created by DiskoBlock has a finalizer, so deletion will be blocked until coresponding DiskConfig is exists
+  - by default every resource created by DiscoBlock has a finalizer, so resource deletion would be on hold by Kubernetes until corresponding DiskConfig is exists
   - by default every additional disk has owner reference to the first disk ever created for pod, Deletion of first PVC terminates all other
 
 At the current stage, Discoblocks is leveraging the available hyperscaler CSI (Container Storage Interface) within the Kubernetes cluster to:
@@ -60,7 +60,7 @@ At the current stage, Discoblocks is leveraging the available hyperscaler CSI (C
   - availability mode:
     - ReadWriteOnce: New disk for each pod, including pod restart
     - ReadWriteSame: All pod gets the same volume on the same node
-    - ReadWriteDaemon: DaemonSet pods gets the same volume per node
+    - ReadWriteDaemon: DaemonSet pods always re-use existing volume on the same node
   - upscale policy
     - upscale trigger percentage
     - maximum capacity of disk

--- a/api/v1/diskconfig_types.go
+++ b/api/v1/diskconfig_types.go
@@ -130,12 +130,13 @@ const (
 	Deleting Phase = "Deleting"
 )
 
-// +kubebuilder:validation:Enum=ReadWriteSame;ReadWriteOnce
+// +kubebuilder:validation:Enum=ReadWriteSame;ReadWriteOnce;ReadWriteDaemon
 type AvailabilityMode string
 
 const (
-	ReadWriteSame AvailabilityMode = "ReadWriteSame"
-	ReadWriteOnce AvailabilityMode = "ReadWriteOnce"
+	ReadWriteSame   AvailabilityMode = "ReadWriteSame"
+	ReadWriteOnce   AvailabilityMode = "ReadWriteOnce"
+	ReadWriteDaemon AvailabilityMode = "ReadWriteDaemon"
 )
 
 //+kubebuilder:object:root=true

--- a/api/v1/diskconfig_webhook.go
+++ b/api/v1/diskconfig_webhook.go
@@ -19,7 +19,6 @@ package v1
 import (
 	"errors"
 	"fmt"
-	"reflect"
 	"regexp"
 	"strings"
 	"time"
@@ -92,11 +91,6 @@ func (r *DiskConfig) validate(old runtime.Object) error {
 			err := errors.New("invalid old object")
 			logger.Error(err, "this should not happen")
 			return err
-		}
-
-		if !reflect.DeepEqual(oldDC.Spec.AccessModes, r.Spec.AccessModes) {
-			logger.Info("AccessModes is immutable")
-			return errors.New("access modes is immutable field")
 		}
 
 		if oldDC.Spec.StorageClassName != r.Spec.StorageClassName {

--- a/api/v1/diskconfig_webhook.go
+++ b/api/v1/diskconfig_webhook.go
@@ -51,7 +51,7 @@ func (r *DiskConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-//+kubebuilder:webhook:path=/validate-discoblocks-ondat-io-v1-diskconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=discoblocks.ondat.io,resources=diskconfigs,verbs=create;update;delete,versions=v1,name=validatediskconfig.kb.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/validate-discoblocks-ondat-io-v1-diskconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=discoblocks.ondat.io,resources=diskconfigs,verbs=create;update,versions=v1,name=validatediskconfig.kb.io,admissionReviewVersions=v1
 
 var _ webhook.Validator = &DiskConfig{}
 
@@ -66,7 +66,7 @@ func (r *DiskConfig) ValidateUpdate(old runtime.Object) error {
 }
 
 func (r *DiskConfig) validate(old runtime.Object) error {
-	logger := diskConfigLog.WithValues("name", r.Name, "namespace", r.Namespace)
+	logger := diskConfigLog.WithValues("dc_name", r.Name, "namespace", r.Namespace)
 
 	logger.Info("Validate update...")
 	defer logger.Info("Validated")
@@ -161,8 +161,6 @@ func (r *DiskConfig) validate(old runtime.Object) error {
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *DiskConfig) ValidateDelete() error {
-	diskConfigLog.Info("validate delete", "name", r.Name)
-
 	return nil
 }
 

--- a/config/crd/bases/discoblocks.ondat.io_diskconfigs.yaml
+++ b/config/crd/bases/discoblocks.ondat.io_diskconfigs.yaml
@@ -49,6 +49,7 @@ spec:
                 enum:
                 - ReadWriteSame
                 - ReadWriteOnce
+                - ReadWriteDaemon
                 type: string
               capacity:
                 anyOf:

--- a/config/manager/config.yaml
+++ b/config/manager/config.yaml
@@ -13,6 +13,6 @@ data:
       plugins:
         filter:
           enabled:
-          - name: PodFilter
+          - name: PodScheduler
     leaderElection:
       leaderElect: false

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -48,7 +48,7 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pod
+  - pods
   verbs:
   - delete
   - get

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -23,7 +23,7 @@ webhooks:
     - CREATE
     resources:
     - pods
-  sideEffects: None
+  sideEffects: NoneOnDryRun
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -48,7 +48,6 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
-    - DELETE
     resources:
     - diskconfigs
   sideEffects: None

--- a/controllers/diskconfig_controller.go
+++ b/controllers/diskconfig_controller.go
@@ -65,7 +65,7 @@ type DiskConfigReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.11.0/pkg/reconcile
 func (r *DiskConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := log.FromContext(ctx).WithName("DiskConfigReconciler").WithValues("name", req.Name, "namespace", req.Name)
+	logger := log.FromContext(ctx).WithName("DiskConfigReconciler").WithValues("req_name", req.Name, "namespace", req.Name)
 
 	lock, unlock := controllerSemaphore()
 	if !lock {

--- a/controllers/job_controller.go
+++ b/controllers/job_controller.go
@@ -36,7 +36,7 @@ type JobReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.11.0/pkg/reconcile
 func (r *JobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := log.FromContext(ctx).WithName("JobReconciler").WithValues("name", req.Name, "namespace", req.Name)
+	logger := log.FromContext(ctx).WithName("JobReconciler").WithValues("req_name", req.Name, "namespace", req.Name)
 
 	logger.Info("Reconcile job...")
 	defer logger.Info("Reconciled")
@@ -60,14 +60,14 @@ func (r *JobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	}
 
 	for i := range podList.Items {
-		logger.Info("Delete Pod...", "name", podList.Items[i].Name)
+		logger.Info("Delete Pod...", "pod_name", podList.Items[i].Name)
 
 		if err := r.Client.Delete(ctx, &podList.Items[i]); err != nil {
 			if apierrors.IsNotFound(err) {
 				continue
 			}
 
-			logger.Info("Failed to delete pod", "name", podList.Items[i].Name, "error", err.Error())
+			logger.Info("Failed to delete pod", "pod_name", podList.Items[i].Name, "error", err.Error())
 			return ctrl.Result{}, fmt.Errorf("unable to delete pod %s: %w", podList.Items[i].Name, err)
 		}
 	}

--- a/controllers/pod_controller.go
+++ b/controllers/pod_controller.go
@@ -35,7 +35,7 @@ type PodReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.11.0/pkg/reconcile
 func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := logf.FromContext(ctx).WithName("PodReconciler").WithValues("name", req.Name, "namespace", req.Name)
+	logger := logf.FromContext(ctx).WithName("PodReconciler").WithValues("req_name", req.Name, "namespace", req.Name)
 
 	logger.Info("Reconcile pod...")
 	defer logger.Info("Reconciled")

--- a/drivers/ebs.csi.aws.com/main.go
+++ b/drivers/ebs.csi.aws.com/main.go
@@ -13,8 +13,8 @@ func main() {}
 func IsStorageClassValid() {
 	json := []byte(os.Getenv("STORAGE_CLASS_JSON"))
 
-	if fastjson.Exists(json, "volumeBindingMode") && fastjson.GetString(json, "volumeBindingMode") != "Immediate" {
-		fmt.Fprint(os.Stderr, "only volumeBindingMode Immediate is supported")
+	if !fastjson.Exists(json, "volumeBindingMode") || fastjson.GetString(json, "volumeBindingMode") != "WaitForFirstConsumer" {
+		fmt.Fprint(os.Stderr, "only volumeBindingMode WaitForFirstConsumer is supported")
 		fmt.Fprint(os.Stdout, false)
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ var (
 //+kubebuilder:rbac:groups="",resources=services,verbs=create;update;delete
 //+kubebuilder:rbac:groups="",resources=services/finalizers,verbs=update
 //+kubebuilder:rbac:groups="",resources=endpoints,verbs=list;watch
-//+kubebuilder:rbac:groups="",resources=pod,verbs=get;delete
+//+kubebuilder:rbac:groups="",resources=pods,verbs=get;delete
 
 // indirect rbac
 //+kubebuilder:rbac:groups="",resources=namespaces;services;pods;persistentvolumes;replicationcontrollers,verbs=list;watch
@@ -162,9 +162,10 @@ func main() {
 	discoblocksondatiov1.InitDiskConfigWebhookDeps(mgr.GetClient(), provisioners)
 
 	if err = (&discoblocksondatiov1.DiskConfig{}).SetupWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "DiskConfig")
+		setupLog.Error(err, "unable to create validator", "validator", "DiskConfig")
 		os.Exit(1)
 	}
+
 	//+kubebuilder:scaffold:builder
 
 	strictMutator, err := parseBoolEnv("MUTATOR_STRICT_MODE")

--- a/pkg/utils/helpers.go
+++ b/pkg/utils/helpers.go
@@ -93,8 +93,8 @@ func RenderResourceName(prefix bool, elems ...string) (string, error) {
 	return builder.String()[:l], nil
 }
 
-// RenderDiskConfigLabel renders DiskConfig label
-func RenderDiskConfigLabel(name string) string {
+// RenderUniqueLabel renders DiskConfig label
+func RenderUniqueLabel(name string) string {
 	hash, err := Hash(name)
 	if err != nil {
 		panic("Unable to calculate hash, better to say good bye!")
@@ -116,12 +116,14 @@ func IsContainsAll(a, b map[string]string) bool {
 }
 
 // GetNamePrefix returns the prefix by availability type
-func GetNamePrefix(am discoblocksondatiov1.AvailabilityMode, uniquePerConfig string) string {
+func GetNamePrefix(am discoblocksondatiov1.AvailabilityMode, configUID, nodeName string) string {
 	switch am {
 	case discoblocksondatiov1.ReadWriteOnce:
 		return time.Now().String()
 	case discoblocksondatiov1.ReadWriteSame:
-		return uniquePerConfig
+		return configUID
+	case discoblocksondatiov1.ReadWriteDaemon:
+		return nodeName
 	default:
 		panic("Missing availability mode implementation: " + string(am))
 	}

--- a/schedulers/pod.go
+++ b/schedulers/pod.go
@@ -18,28 +18,28 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type podFilter struct {
+type podSCheduler struct {
 	client.Client
 	strict bool
 	logger logr.Logger
 }
 
 // Name returns the name of plugin
-func (s *podFilter) Name() string {
-	return "PodFilter"
+func (s *podSCheduler) Name() string {
+	return "PodScheduler"
 }
 
 // Filter does the filtering
-func (s *podFilter) Filter(ctx context.Context, state *framework.CycleState, pod *corev1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
-	logger := s.logger.WithValues("pod", pod.Name, "namespace", pod.Namespace, "node", nodeInfo.Node().Name)
+func (s *podSCheduler) Filter(ctx context.Context, state *framework.CycleState, pod *corev1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
+	logger := s.logger.WithValues("pod_name", pod.Name, "namespace", pod.Namespace, "node", nodeInfo.Node().Name)
 
 	errorStatus := framework.Success
 	if s.strict {
 		errorStatus = framework.Error
 	}
 
-	logger.Info("Scheduling...")
-	defer logger.Info("Scheduled")
+	logger.Info("Filtering...")
+	defer logger.Info("Filtered")
 
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
@@ -140,6 +140,6 @@ func (s *podFilter) Filter(ctx context.Context, state *framework.CycleState, pod
 }
 
 // Factory framework compatible factory
-func (s *podFilter) Factory(configuration runtime.Object, f framework.Handle) (framework.Plugin, error) {
+func (s *podSCheduler) Factory(configuration runtime.Object, f framework.Handle) (framework.Plugin, error) {
 	return s, nil
 }

--- a/schedulers/scheduler.go
+++ b/schedulers/scheduler.go
@@ -30,13 +30,13 @@ func (s *Scheduler) Start(ctx context.Context) <-chan error {
 		defer s.logger.Info("Plugin stop")
 		defer close(errChan)
 
-		podFilterPlugin := podFilter{
+		podSchedulerPlugin := podSCheduler{
 			Client: s.Client,
 			strict: s.strict,
 			logger: s.logger.WithName("Pod"),
 		}
 
-		command := scheduler.NewSchedulerCommand(scheduler.WithPlugin(podFilterPlugin.Name(), podFilterPlugin.Factory))
+		command := scheduler.NewSchedulerCommand(scheduler.WithPlugin(podSchedulerPlugin.Name(), podSchedulerPlugin.Factory))
 		command.SetOut(&logWriter{s.logger})
 		command.SetErr(os.Stderr)
 		command.SetArgs([]string{"--config=/etc/kubernetes/discoblocks-scheduler/scheduler-config.yaml"})

--- a/tests/e2e/kuttl/kuttl-config-1.23.yaml
+++ b/tests/e2e/kuttl/kuttl-config-1.23.yaml
@@ -3,7 +3,7 @@ kind: TestSuite
 testDirs:
 - ./tests/e2e/stable
 kindConfig: tests/e2e/kind/kind-config-1.23.yaml
-startKIND: false
+startKIND: true
 kindContainers:
   - local/discoblocks:e2e
 timeout: 400

--- a/tests/e2e/kuttl/kuttl-config-1.23.yaml
+++ b/tests/e2e/kuttl/kuttl-config-1.23.yaml
@@ -3,7 +3,7 @@ kind: TestSuite
 testDirs:
 - ./tests/e2e/stable
 kindConfig: tests/e2e/kind/kind-config-1.23.yaml
-startKIND: true
+startKIND: false
 kindContainers:
   - local/discoblocks:e2e
 timeout: 400

--- a/tests/e2e/stable/storageos/01-assert.yaml
+++ b/tests/e2e/stable/storageos/01-assert.yaml
@@ -35,7 +35,7 @@ metadata:
   labels:
     app: discoblocks
     app.kubernetes.io/component: discoblocks
-  name: mutating-webhook-configuration
+  name: discoblocks-mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
   - v1
@@ -58,7 +58,7 @@ metadata:
   labels:
     app: discoblocks
     app.kubernetes.io/component: discoblocks
-  name: validating-webhook-configuration
+  name: discoblocks-validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
   - v1

--- a/tests/e2e/stable/storageos/01-assert.yaml
+++ b/tests/e2e/stable/storageos/01-assert.yaml
@@ -35,7 +35,7 @@ metadata:
   labels:
     app: discoblocks
     app.kubernetes.io/component: discoblocks
-  name: discoblocks-mutating-webhook-configuration
+  name: mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
   - v1
@@ -55,7 +55,9 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
+  labels:
+    app: discoblocks
+    app.kubernetes.io/component: discoblocks
   name: validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:

--- a/tests/e2e/stable/storageos/01-assert.yaml
+++ b/tests/e2e/stable/storageos/01-assert.yaml
@@ -39,6 +39,11 @@ metadata:
 webhooks:
 - admissionReviewVersions:
   - v1
+  clientConfig:
+    service:
+      name: discoblocks-webhook-service
+      namespace: kube-system
+      path: /mutate-v1-pod
   reinvocationPolicy: Never
   rules:
   - apiGroups:
@@ -64,8 +69,8 @@ webhooks:
   - v1
   clientConfig:
     service:
-      name: webhook-service
-      namespace: system
+      name: discoblocks-webhook-service
+      namespace: kube-system
       path: /validate-discoblocks-ondat-io-v1-diskconfig
   failurePolicy: Fail
   name: validatediskconfig.kb.io

--- a/tests/e2e/stable/storageos/01-assert.yaml
+++ b/tests/e2e/stable/storageos/01-assert.yaml
@@ -50,4 +50,31 @@ webhooks:
     resources:
     - pods
     scope: '*'
+  sideEffects: NoneOnDryRun
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-discoblocks-ondat-io-v1-diskconfig
+  failurePolicy: Fail
+  name: validatediskconfig.kb.io
+  rules:
+  - apiGroups:
+    - discoblocks.ondat.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - diskconfigs
   sideEffects: None

--- a/tests/e2e/stable/storageos/02-assert.yaml
+++ b/tests/e2e/stable/storageos/02-assert.yaml
@@ -39,6 +39,19 @@ spec:
     maximumNumberOfDisks: 2
     coolDown: 1s
 ---
+apiVersion: discoblocks.ondat.io/v1
+kind: DiskConfig
+metadata:
+  name: diskconfig-sample-storageos-daemon
+  namespace: kube-system
+spec:
+  storageClassName: storageos
+  capacity: 1Gi
+  availabilityMode: ReadWriteDaemon
+  mountPointPattern: /media/discoblocks/same-%d
+  podSelector:
+    name: fluentd-elasticsearch
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -48,3 +61,13 @@ metadata:
   namespace: default
 status:
   availableReplicas: 1
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    k8s-app: fluentd-logging
+  name: fluentd-elasticsearch
+  namespace: kube-system
+status:
+  currentNumberScheduled: 1

--- a/tests/e2e/stable/storageos/02-assert.yaml
+++ b/tests/e2e/stable/storageos/02-assert.yaml
@@ -48,7 +48,7 @@ spec:
   storageClassName: storageos
   capacity: 1Gi
   availabilityMode: ReadWriteDaemon
-  mountPointPattern: /media/discoblocks/same-%d
+  mountPointPattern: /media/discoblocks/daemon-%d
   podSelector:
     name: fluentd-elasticsearch
 ---

--- a/tests/e2e/stable/storageos/02-install-workload.yaml
+++ b/tests/e2e/stable/storageos/02-install-workload.yaml
@@ -4,3 +4,5 @@ commands:
   - command: kubectl apply -f diskconfig-readwriteonce.yaml
   - command: kubectl apply -f diskconfig-readwritesame.yaml
   - command: kubectl create deployment --image=nginx:1.23 nginx
+  - command: kubectl apply -f diskconfig-readwritedaemon.yaml
+  - command: kubectl apply -f https://k8s.io/examples/controllers/daemonset.yaml

--- a/tests/e2e/stable/storageos/03-assert.tpl.yaml
+++ b/tests/e2e/stable/storageos/03-assert.tpl.yaml
@@ -133,7 +133,7 @@ metadata:
   name: #PV_SAME_NAME#
 spec:
   accessModes:
-  - ReadOnlyMany
+  - ReadWriteOnce
   capacity:
     storage: 1Gi
   persistentVolumeReclaimPolicy: Delete

--- a/tests/e2e/stable/storageos/03-assert.tpl.yaml
+++ b/tests/e2e/stable/storageos/03-assert.tpl.yaml
@@ -173,25 +173,7 @@ metadata:
 spec:
   containers:
   - image: nginx:1.23
-  # Order of mounts is not guaranteed
-  #   volumeMounts:
-  #   - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-  #   - mountPath: /media/discoblocks/same-0
-  #   - mountPath: /media/discoblocks/once-0
-  # - image: bitnami/node-exporter:1.3.1
-  #   volumeMounts:
-  #   - mountPath: /media/discoblocks/once-0
-  #   - mountPath: /media/discoblocks/same-0
-  #   - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-  volumes:
-  - projected:
-      defaultMode: 420
-  - name: #PVC_ONCE_NAME#
-    persistentVolumeClaim:
-      claimName: #PVC_ONCE_NAME#
-  - name: #PVC_SAME_NAME#
-    persistentVolumeClaim:
-      claimName: #PVC_SAME_NAME#
+  - image: bitnami/node-exporter:1.3.1
 status:
   phase: Running
 ---

--- a/tests/e2e/stable/storageos/03-assert.tpl.yaml
+++ b/tests/e2e/stable/storageos/03-assert.tpl.yaml
@@ -175,8 +175,8 @@ spec:
   - image: nginx:1.23
     volumeMounts:
     - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-    - mountPath: /media/discoblocks/once-0
     - mountPath: /media/discoblocks/same-0
+    - mountPath: /media/discoblocks/once-0
   - image: bitnami/node-exporter:1.3.1
     volumeMounts:
     - mountPath: /media/discoblocks/once-0

--- a/tests/e2e/stable/storageos/03-assert.tpl.yaml
+++ b/tests/e2e/stable/storageos/03-assert.tpl.yaml
@@ -133,7 +133,7 @@ metadata:
   name: #PV_SAME_NAME#
 spec:
   accessModes:
-  - ReadWriteOnce
+  - ReadWriteMany
   capacity:
     storage: 1Gi
   persistentVolumeReclaimPolicy: Delete
@@ -151,7 +151,7 @@ metadata:
   name: #PV_DAEMON_NAME#
 spec:
   accessModes:
-  - ReadWriteMany
+  - ReadWriteOnce
   capacity:
     storage: 1Gi
   persistentVolumeReclaimPolicy: Delete

--- a/tests/e2e/stable/storageos/03-assert.tpl.yaml
+++ b/tests/e2e/stable/storageos/03-assert.tpl.yaml
@@ -77,6 +77,54 @@ status:
   phase: Bound
 ---
 apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    pv.kubernetes.io/bind-completed: "yes"
+    pv.kubernetes.io/bound-by-controller: "yes"
+    volume.beta.kubernetes.io/storage-provisioner: csi.storageos.com
+    volume.kubernetes.io/storage-provisioner: csi.storageos.com
+  finalizers:
+  - discoblocks.io/diskconfig-sample-storageos-daemon
+  - kubernetes.io/pvc-protection
+  labels:
+    discoblocks: diskconfig-sample-storageos-daemon
+  name: #PVC_DAEMON_NAME#
+  namespace: default
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: storageos
+  volumeMode: Filesystem
+status:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  phase: Bound
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  finalizers:
+  - kubernetes.io/pv-protection
+  - external-attacher/csi-storageos-com
+  name: #PV_ONCE_NAME#
+spec:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  persistentVolumeReclaimPolicy: Delete
+  storageClassName: storageos
+  volumeMode: Filesystem
+status:
+  phase: Bound
+---
+apiVersion: v1
 kind: PersistentVolume
 metadata:
   finalizers:
@@ -86,6 +134,24 @@ metadata:
 spec:
   accessModes:
   - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  persistentVolumeReclaimPolicy: Delete
+  storageClassName: storageos
+  volumeMode: Filesystem
+status:
+  phase: Bound
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  finalizers:
+  - kubernetes.io/pv-protection
+  - external-attacher/csi-storageos-com
+  name: #PV_DAEMON_NAME#
+spec:
+  accessModes:
+  - ReadWriteMany
   capacity:
     storage: 1Gi
   persistentVolumeReclaimPolicy: Delete

--- a/tests/e2e/stable/storageos/03-assert.tpl.yaml
+++ b/tests/e2e/stable/storageos/03-assert.tpl.yaml
@@ -173,15 +173,16 @@ metadata:
 spec:
   containers:
   - image: nginx:1.23
-    volumeMounts:
-    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-    - mountPath: /media/discoblocks/same-0
-    - mountPath: /media/discoblocks/once-0
-  - image: bitnami/node-exporter:1.3.1
-    volumeMounts:
-    - mountPath: /media/discoblocks/once-0
-    - mountPath: /media/discoblocks/same-0
-    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+  # Order of mounts is not guaranteed
+  #   volumeMounts:
+  #   - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+  #   - mountPath: /media/discoblocks/same-0
+  #   - mountPath: /media/discoblocks/once-0
+  # - image: bitnami/node-exporter:1.3.1
+  #   volumeMounts:
+  #   - mountPath: /media/discoblocks/once-0
+  #   - mountPath: /media/discoblocks/same-0
+  #   - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
   volumes:
   - projected:
       defaultMode: 420

--- a/tests/e2e/stable/storageos/03-assert.tpl.yaml
+++ b/tests/e2e/stable/storageos/03-assert.tpl.yaml
@@ -90,7 +90,7 @@ metadata:
   labels:
     discoblocks: diskconfig-sample-storageos-daemon
   name: #PVC_DAEMON_NAME#
-  namespace: default
+  namespace: kube-system
 spec:
   accessModes:
   - ReadWriteOnce

--- a/tests/e2e/stable/storageos/03-assert.tpl.yaml
+++ b/tests/e2e/stable/storageos/03-assert.tpl.yaml
@@ -133,7 +133,7 @@ metadata:
   name: #PV_SAME_NAME#
 spec:
   accessModes:
-  - ReadWriteMany
+  - ReadOnlyMany
   capacity:
     storage: 1Gi
   persistentVolumeReclaimPolicy: Delete

--- a/tests/e2e/stable/storageos/03-validate.yaml
+++ b/tests/e2e/stable/storageos/03-validate.yaml
@@ -7,8 +7,8 @@ commands:
       -e "s/#PV_ONCE_NAME#/$(kubectl get pvc -l discoblocks=diskconfig-sample-storageos-once --no-headers -o custom-columns=":spec.volumeName")/" \
       -e "s/#PVC_SAME_NAME#/$(kubectl get pvc -l discoblocks=diskconfig-sample-storageos-same --no-headers -o custom-columns=":metadata.name")/" \
       -e "s/#PV_SAME_NAME#/$(kubectl get pvc -l discoblocks=diskconfig-sample-storageos-same --no-headers -o custom-columns=":spec.volumeName")/" \
-      -e "s/#PVC_DAEMON_NAME#/$(kubectl get pvc -l discoblocks=diskconfig-sample-storageos-daemon --no-headers -o custom-columns=":metadata.name")/" \
-      -e "s/#PV_DAEMON_NAME#/$(kubectl get pvc -l discoblocks=diskconfig-sample-storageos-daemon --no-headers -o custom-columns=":spec.volumeName")/" \
+      -e "s/#PVC_DAEMON_NAME#/$(kubectl get pvc -n kube-system -l discoblocks=diskconfig-sample-storageos-daemon --no-headers -o custom-columns=":metadata.name")/" \
+      -e "s/#PV_DAEMON_NAME#/$(kubectl get pvc -n kube-system -l discoblocks=diskconfig-sample-storageos-daemon --no-headers -o custom-columns=":spec.volumeName")/" \
       -e "s/#POD_NAME#/$(kubectl get po -l app=nginx --no-headers -o custom-columns=":metadata.name")/" \
       -e "s/#SERVICE_NAME#/$(kubectl get service -l discoblocks --no-headers -o custom-columns=":metadata.name")/" \
       > workload/00-assert.yaml'

--- a/tests/e2e/stable/storageos/03-validate.yaml
+++ b/tests/e2e/stable/storageos/03-validate.yaml
@@ -7,6 +7,8 @@ commands:
       -e "s/#PV_ONCE_NAME#/$(kubectl get pvc -l discoblocks=diskconfig-sample-storageos-once --no-headers -o custom-columns=":spec.volumeName")/" \
       -e "s/#PVC_SAME_NAME#/$(kubectl get pvc -l discoblocks=diskconfig-sample-storageos-same --no-headers -o custom-columns=":metadata.name")/" \
       -e "s/#PV_SAME_NAME#/$(kubectl get pvc -l discoblocks=diskconfig-sample-storageos-same --no-headers -o custom-columns=":spec.volumeName")/" \
+      -e "s/#PVC_DAEMON_NAME#/$(kubectl get pvc -l discoblocks=diskconfig-sample-storageos-daemon --no-headers -o custom-columns=":metadata.name")/" \
+      -e "s/#PV_DAEMON_NAME#/$(kubectl get pvc -l discoblocks=diskconfig-sample-storageos-daemon --no-headers -o custom-columns=":spec.volumeName")/" \
       -e "s/#POD_NAME#/$(kubectl get po -l app=nginx --no-headers -o custom-columns=":metadata.name")/" \
       -e "s/#SERVICE_NAME#/$(kubectl get service -l discoblocks --no-headers -o custom-columns=":metadata.name")/" \
       > workload/00-assert.yaml'

--- a/tests/e2e/stable/storageos/04-fill-volume.yaml
+++ b/tests/e2e/stable/storageos/04-fill-volume.yaml
@@ -9,3 +9,4 @@ commands:
   - command: sleep 40
   - command: sh -c "kubectl exec $(kubectl get po --no-headers | tail -1 | awk '{print $1}') -- dd if=/dev/zero of=/media/discoblocks/same-1/data1 count=3000000"
   - command: sleep 40
+  - command: sh -c "kubectl exec -n kube-system $(kubectl get po -n kube-system -l name=fluentd-elasticsearch --no-headers | tail -1 | awk '{print $1}') -- touch /media/discoblocks/daemon-0/data0"

--- a/tests/e2e/stable/storageos/05-assert.yaml
+++ b/tests/e2e/stable/storageos/05-assert.yaml
@@ -7,3 +7,13 @@ metadata:
   namespace: default
 status:
   availableReplicas: 1
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    k8s-app: fluentd-logging
+  name: fluentd-elasticsearch
+  namespace: kube-system
+status:
+  currentNumberScheduled: 1

--- a/tests/e2e/stable/storageos/05-restart-workload.yaml
+++ b/tests/e2e/stable/storageos/05-restart-workload.yaml
@@ -2,3 +2,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - command: sh -c "kubectl delete po $(kubectl get po -l app=nginx --no-headers -o custom-columns=":metadata.name")"
+  - command: sh -c "kubectl delete po -n kube-system $(kubectl get po -n kube-system -l name=fluentd-elasticsearch --no-headers -o custom-columns=":metadata.name")"

--- a/tests/e2e/stable/storageos/06-validate-volumes.yaml
+++ b/tests/e2e/stable/storageos/06-validate-volumes.yaml
@@ -3,3 +3,4 @@ kind: TestStep
 commands:
   - command: sh -c "kubectl exec $(kubectl get po | tail -1 | awk '{print $1}') -- ls -l /media/discoblocks/same-0/data0"
   - command: sh -c "kubectl exec $(kubectl get po | tail -1 | awk '{print $1}') -- ls -l /media/discoblocks/same-1/data1"
+  - command: sh -c "kubectl exec -n kube-system $(kubectl get po -n kube-system -l name=fluentd-elasticsearch --no-headers | tail -1 | awk '{print $1}') -- ls -l /media/discoblocks/daemon-0/data0"

--- a/tests/e2e/stable/storageos/diskconfig-readwritedaemon.yaml
+++ b/tests/e2e/stable/storageos/diskconfig-readwritedaemon.yaml
@@ -9,8 +9,6 @@ spec:
   storageClassName: storageos
   capacity: 1Gi
   availabilityMode: ReadWriteDaemon
-  accessModes:
-  - ReadWriteMany
   mountPointPattern: /media/discoblocks/daemon-%d
   podSelector:
     name: fluentd-elasticsearch

--- a/tests/e2e/stable/storageos/diskconfig-readwritedaemon.yaml
+++ b/tests/e2e/stable/storageos/diskconfig-readwritedaemon.yaml
@@ -1,0 +1,16 @@
+apiVersion: discoblocks.ondat.io/v1
+kind: DiskConfig
+metadata:
+  name: diskconfig-sample-storageos-daemon
+  namespace: kube-system
+  labels:
+    discoblocks: ok
+spec:
+  storageClassName: storageos
+  capacity: 1Gi
+  availabilityMode: ReadWriteDaemon
+  accessModes:
+  - ReadWriteMany
+  mountPointPattern: /media/discoblocks/daemon-%d
+  podSelector:
+    name: fluentd-elasticsearch

--- a/tests/e2e/stable/storageos/diskconfig-readwritesame.yaml
+++ b/tests/e2e/stable/storageos/diskconfig-readwritesame.yaml
@@ -8,6 +8,8 @@ spec:
   storageClassName: storageos
   capacity: 1Gi
   availabilityMode: ReadWriteSame
+  accessModes:
+  - ReadWriteMany
   mountPointPattern: /media/discoblocks/same-%d
   nodeSelector:
     matchLabels:

--- a/tests/e2e/stable/storageos/diskconfig-readwritesame.yaml
+++ b/tests/e2e/stable/storageos/diskconfig-readwritesame.yaml
@@ -9,7 +9,7 @@ spec:
   capacity: 1Gi
   availabilityMode: ReadWriteSame
   accessModes:
-  - ReadWriteMany
+  - ReadOnlyMany
   mountPointPattern: /media/discoblocks/same-%d
   nodeSelector:
     matchLabels:

--- a/tests/e2e/stable/storageos/diskconfig-readwritesame.yaml
+++ b/tests/e2e/stable/storageos/diskconfig-readwritesame.yaml
@@ -9,7 +9,7 @@ spec:
   capacity: 1Gi
   availabilityMode: ReadWriteSame
   accessModes:
-  - ReadOnlyMany
+  - ReadWriteOnce
   mountPointPattern: /media/discoblocks/same-%d
   nodeSelector:
     matchLabels:


### PR DESCRIPTION
## Description

Currently, there are two availability options, readwriteonce, readwritesame. In the case of daemonset readwritesame isn't an option, because all pods are scheduled to the same node. On the other hand with readwriteonce, the daemonset pods get fresh new PVCs, so they lose connection with the volume after the restart. It would be nice to support daemonsets by configuring per node volumes.

Fixes #
https://github.com/ondat/discoblocks/issues/50
https://github.com/ondat/discoblocks/issues/59

## Type of change

Please check options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
