### PR TITLE
Min cooldown

### DIFF
--- a/api/v1/diskconfig_types.go
+++ b/api/v1/diskconfig_types.go
@@ -95,7 +95,7 @@ type Policy struct {
 	//+kubebuilder:validation:Optional
 	ExtendCapacity resource.Quantity `json:"extendCapacity,omitempty" yaml:"extendCapacity,omitempty"`
 
-	// CoolDown defines temporary pause of scaling.
+	// CoolDown defines temporary pause of scaling. Minimum: 10s
 	//+kubebuilder:default:="5m"
 	//+kubebuilder:validation:Optional
 	CoolDown metav1.Duration `json:"coolDown,omitempty" yaml:"coolDown,omitempty"`

--- a/api/v1/diskconfig_webhook.go
+++ b/api/v1/diskconfig_webhook.go
@@ -85,6 +85,13 @@ func (r *DiskConfig) validate(old runtime.Object) error {
 		return err
 	}
 
+	const ten = 10
+	if r.Spec.Policy.CoolDown.Duration < ten*time.Second {
+		err := fmt.Errorf("minimum cool down is %d seconds", ten)
+		logger.Info("Invalid cool down", "error", err.Error())
+		return err
+	}
+
 	if old != nil {
 		oldDC, ok := old.(*DiskConfig)
 		if !ok {

--- a/config/crd/bases/discoblocks.ondat.io_diskconfigs.yaml
+++ b/config/crd/bases/discoblocks.ondat.io_diskconfigs.yaml
@@ -125,7 +125,8 @@ spec:
                 properties:
                   coolDown:
                     default: 5m
-                    description: CoolDown defines temporary pause of scaling.
+                    description: 'CoolDown defines temporary pause of scaling. Minimum:
+                      10s'
                     type: string
                   extendCapacity:
                     anyOf:


### PR DESCRIPTION
The system uses the minimum cooldown for operation timeouts to avoid multiple executions. A very low value causes operation timeouts.